### PR TITLE
Feedback

### DIFF
--- a/sass/_attend.scss
+++ b/sass/_attend.scss
@@ -38,6 +38,30 @@
             &.reverse {
                 flex-wrap: wrap-reverse;
             }
+
+            .public-transport {
+                padding: 0.2em;
+                font-weight: bold;
+                color: #FFFFFF;
+            }
+
+            .public-transport-round {
+                border-radius: 1em;
+            }
+
+            .public-transport-bus {
+                background-color: #A5027d;
+            }
+
+            .public-transport-s-bahn {
+                background-color: #008D4F;
+                padding-inline: 0.4em;
+            }
+
+            .public-transport-u-bahn {
+                background-color: #004F8D;
+                padding-inline: 0.4em;
+            }
         }
     }
 }

--- a/sass/_index.scss
+++ b/sass/_index.scss
@@ -55,6 +55,7 @@
                 font-weight: 700;
                 padding: 2.4em;
                 text-align: center;
+                margin: auto;
 
                 width: 400px;
                 height: 400px;

--- a/templates/attend.html
+++ b/templates/attend.html
@@ -62,7 +62,7 @@
                     <p>We expect people to stay home if they may be contagious. If you are feeling sick or exhibiting
                         symptoms of COVID-19, or test positive for COVID-19, prior to the start of the conference, or on
                         any
-                        day of the conference, please contact us at conference@matrix.org. We will exchange your ticket
+                        day of the conference, please contact us at <a href="mailto:conference@foundation.matrix.org">conference@foundation.matrix.org</a>. We will exchange your ticket
                         type
                         for an online ticket or grant you a refund.</p>
                     <p>Onsite attendees will be able to watch talks online while they recover, wait for the results of a
@@ -72,7 +72,7 @@
                     <p>All the food provided at the Matrix Conference will be vegan, which accommodates a wide range of
                         dietary restrictions. All foods will be labelled at the event. If you have food allergies,
                         please
-                        reach out to us at conference@matrix.org</p>
+                        reach out to us at <a href="mailto:conference@foundation.matrix.org">conference@foundation.matrix.org</a>.</p>
                 </div>
             </div>
         </div>
@@ -87,11 +87,11 @@
                         the U-Bahn, S-Bahn, or Bus.
                     </p>
                     <ul>
-                        <li>U-Bahn: U7 stopping at Rathaus Neukölln. From there it is a 500 meter walk.</li>
-                        <li>S-Bahn: Ringbahn S41 & S42 stopping at Sonnenallee. From S Sonnenallee you can take bus line
-                            M41 four stops to Fuldastraße, which is 120 meters down the street from the venue.</li>
-                        <li>Bus lines: the nearest bus stop is Fuldastraße on line M41.</li>
-                        <li>Night Bus: N7, stopping at Weichselstraße.</li>
+                        <li><span class="public-transport public-transport-u-bahn">U</span> U-Bahn: <span class="public-transport" style="background-color: #009bd5;">U7</span> stopping at Rathaus Neukölln. From there it is a 500 meter walk.</li>
+                        <li><span class="public-transport public-transport-round public-transport-s-bahn">S</span> S-Bahn: Ringbahn <span class="public-transport public-transport-round" style="background-color: #ad5937;">S41</span> & <span class="public-transport public-transport-round" style="background-color: #cb6418;">S42</span> stopping at Sonnenallee. From S Sonnenallee you can take bus line
+                             <span class="public-transport public-transport-bus">M41</span> four stops to Fuldastraße, which is 120 metres down the street from the venue.</li>
+                        <li>Bus lines: the nearest bus stop is Fuldastraße on line <span class="public-transport public-transport-bus">M41</span>.</li>
+                        <li>Night Bus: <span class="public-transport public-transport-bus">N7</span>, stopping at Weichselstraße.</li>
                 </div>
             </div>
             <div class="content blurb-and-image">
@@ -100,8 +100,8 @@
                     <p>We encourage all attendees to privilege the train when it’s a viable option for them, as a
                         collective effort to reduce our carbon footprint.</p>
 
-                    <p>To come from the Central Station (Hauptbahnhof), take bus line M41 at the station itself, and
-                        stop at Fuldastraße. Take in to consideration that the line M41 is often delayed due to traffic.
+                    <p>To come from the Central Station (Hauptbahnhof), take bus line <span class="public-transport public-transport-bus">M41</span> at the station itself, and
+                        stop at Fuldastraße. Take in to consideration that the line <span class="public-transport public-transport-bus">M41</span> is often delayed due to traffic.
                     </p>
                 </div>
                 <img src="https://via.placeholder.com/550x380.png" alt="">
@@ -110,8 +110,8 @@
                 <img src="https://via.placeholder.com/550x380.png" alt="">
                 <div class="col">
                     <h2>Berlin Brandenburg Airport</h2>
-                    <p>From the Airport, starting from Rathaus Neukölln take subway line U7 in the direction of Rudow
-                        all the way to stop “U Rudow”. From there, you can either take express bus line X7 or X71 to
+                    <p>From the Airport, starting from Rathaus Neukölln take subway line <span class="public-transport" style="background-color: #009bd5;">U7</span> in the direction of Rudow
+                        all the way to stop “U Rudow”. From there, you can either take express bus line <span class="public-transport public-transport-bus">X7</span> or <span class="public-transport public-transport-bus">X71</span> to
                         BER.</p>
 
                     <p>Berlin is divided into multiple tariff zones for public transport. Make sure to buy a ticket


### PR DESCRIPTION
- fix some alignment
- add Berlin public transport lines coloring based on wikidata, e.g. https://www.wikidata.org/wiki/Q99725

there is one public transport stop in quotes, the rest aren't. not sure if intentional. highlighting all the stops too seemed like too much.

the become a sponsor graphic's right side is slightly cut off on my phone. not sure how to fix. 
![image](https://github.com/matrix-org/matrix-conf-website/assets/2803622/17f47c98-06fd-4576-9e7d-5c96ffd9d22c)

the nav dropdown on mobile isn't great margin-wise and text is styled differently compared to m.org.

links are blue? sometimes? sometimes buttons are too? that's uncharacteristic.

mobile margin including main content on the whole site feels worse than m.org.