### PR TITLE
copy edits and adding social links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,8 @@
 # The URL the site will be built for
 base_url = "https://2024.matrix.org"
 
-title = "Matrix Conference 2024"
-description = "Matrix Conference - 2024"
+title = "The Matrix Conference 2024"
+description = "The Matrix Conference is coming to Berlin, Germany on September 19–22, 2024."
 
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,5 +1,5 @@
 {% extends "skel.html" %}
-{% block html_title %}Matrix.org - Not Found{% endblock html_title %}
+{% block html_title %}The Matrix Conference - Not Found{% endblock html_title %}
 {% block content %}
 <div class="content">
     <h1>Not Found</h1>

--- a/templates/about.html
+++ b/templates/about.html
@@ -6,8 +6,8 @@
             <div class="hero-text-wrapper">
                 <div class="hero-text">
                     <h1>About the conference</h1>
-                    <p>Join us for first ever Matrix Conf in September 19 - 22. The four days conference will take place
-                        at Mitosis Labs. Talks will be streamed live and virtual attendees will be able to ask speakers
+                    <p>Join us for first ever Matrix Conference in September 19–22. The four day conference will take place
+                        at Mitosis LAB in Berlin. Talks will be streamed live and virtual attendees will be able to ask speakers
                         questions.</p>
                 </div>
             </div>
@@ -19,12 +19,12 @@
             <div class="content blurb-and-image reverse">
                 <img src="/images/amandine.webp" width="550" height="380" alt="">
                 <div class="col">
-                    <h2>What is the Matrix Conf?</h2>
+                    <h2>What is The Matrix Conference?</h2>
                     <p>In summer 2022, the vibrant Matrix community scrambled together to organise the Matrix Community
                         Summit. Hackers, volunteers and developers working on Matrix could join together at c-base to
                         spend some quality time together and share their work.</p>
 
-                    <p>The team behind the Community Summit and the Matrix.org Foundation joined forces to build on the
+                    <p>The team behind the Community Summit and The Matrix.org Foundation joined forces to build on the
                         success of the former, and extend it to audiences from the public and private sector.</p>
                 </div>
             </div>
@@ -47,7 +47,7 @@
                     <h2>Why attend?</h2>
                     <p>The Matrix Conference is mean to be the place where hackers, volunteers, vendors and consumer
                         organisations meet, share their interests, and start working together.</p>
-                    <p>The Conference is THE place to learn, show, hack, hire and contribute to Matrix projects. Whether
+                    <p>The conference is THE place to learn, show, hack, hire and contribute to Matrix projects. Whether
                         you’re an individual or an organisation, this is where the ecosystem blends in.</p>
                     <div class="cta-row">
                         <a href="/register" class="cta">Register</a>

--- a/templates/attend.html
+++ b/templates/attend.html
@@ -6,12 +6,12 @@
             <div class="hero-text-wrapper">
                 <div class="hero-text">
                     <h1>Attend the conference</h1>
-                    <p>Join us for first ever Matrix Conf in September 19 - 22. The four days conference will take place
-                        at Mitosis Labs. Talks will be streamed live and virtual attendees will be able to ask speakers
+                    <p>Join us for first ever Matrix Conference this September 19–22. The four day conference will take place
+                        at Mitosis LAB in Berlin. Talks will be streamed live and virtual attendees will be able to ask speakers
                         questions.</p>
                     <div class="cta-row">
                         <a href="/register" class="cta primary">Get Tickets</a>
-                        <a href="#getting-there" class="cta">Venue info</a>
+                        <a href="#getting-there" class="cta">Venue Info</a>
                     </div>
                 </div>
             </div>
@@ -22,40 +22,32 @@
             <div class="content">
                 <h2>Health & Safety</h2>
                 <div>
-                    <h3>Masks are requred</h3>
+                    <h3>Masks are required</h3>
                     <img class="float-end" src="https://via.placeholder.com/500x380.png" width="500" height="380"
                         alt="">
-                    <p>We are asking you to wear a mask during your time at the Matrix Conferences. That includes talks,
-                        the
-                        booths, BoFs and sprints. Exceptions are:
+                    <p>You need to wear a mask during your time at The Matrix Conference. That includes sessions,
+                        keynotes, booths, open spaces, and sprints. Exceptions are:
                     </p>
                     <ul>
                         <li>Outdoor spaces</li>
                         <li>Indoors while actively consuming food or beverages</li>
                         <li>Speakers while presenting</li>
                         <li>While necessary for communicating with someone who is hearing impaired when the ability to
-                            see
-                            the mouth is essential for communication</li>
+                            see the mouth is essential for communication</li>
                         <li>Very briefly to take photos</li>
                     </ul>
                     <p>Masks must be worn over the nose and mouth and must be made of a tight-knit, non-permeable
-                        material.
-                        N95, FFP2 or equivalent masks are recommended. Alternatives to face coverings such as face
-                        shields,
-                        loose gaiters, scarves, bandanas, and face coverings with ventilation are not permitted to be
-                        used
-                        as
-                        masks.</p>
+                        material. N95, FFP2 or equivalent masks are recommended. Alternatives to face coverings such as face
+                        shields, loose gaiters, scarves, bandanas, and face coverings with ventilation are not permitted to be
+                        used as masks. The Foundation will supply masks on-site.</p>
 
-                    <h3>Vaccinations & Rapid tests are encouraged</h3>
-                    <p>We encourage Matrix Conference attendees to stay up to date with the vaccinations that are
-                        available
-                        to them where they live. We also encourage attendees to use rapid tests (antigen tests) before
-                        they
-                        arrive and while they are at the Conference. The Foundation will not supply rapid tests on-site.
+                    <h3>Vaccinations & rapid tests are encouraged</h3>
+                    <p>We encourage The Matrix Conference attendees to stay up to date with the vaccinations that are
+                        available to them where they live. We also encourage attendees to use rapid tests (antigen tests) before
+                        they arrive and while they are at the conference. The Foundation hopes, but may not be able, to supply rapid tests on-site.
                     </p>
 
-                    <h3>Easy Refunds</h3>
+                    <h3>Easy refunds</h3>
                     <p>We expect people to stay home if they may be contagious. If you are feeling sick or exhibiting
                         symptoms of COVID-19, or test positive for COVID-19, prior to the start of the conference, or on
                         any
@@ -64,14 +56,14 @@
                         exchange your ticket
                         type
                         for an online ticket or grant you a refund.</p>
-                    <p>Onsite attendees will be able to watch talks online while they recover, wait for the results of a
-                        Covid test or sort out any kind of unexpected allergy or “weird cold.”</p>
+                    <p>On-site attendees will be able to watch talks online while they recover, wait for the results of a
+                        COVID test or sort out any kind of unexpected allergy or “weird cold.”</p>
 
                     <h3>Dietary Restrictions</h3>
-                    <p>All the food provided at the Matrix Conference will be vegan, which accommodates a wide range of
-                        dietary restrictions. All foods will be labelled at the event. If you have food allergies,
-                        please
-                        reach out to us at <a
+                    <p>All the food provided at The Matrix Conference will accommodate a wide range of dietary
+                        restrictions. All foods will be labelled at the event. If you have food allergies,
+                        please reach out to us
+                        at <a
                             href="mailto:conference@foundation.matrix.org">conference@foundation.matrix.org</a>.</p>
                 </div>
             </div>

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -11,9 +11,9 @@
         <section>
             <h2>Contact</h2>
             <ul>
-                <li><a href="">Mail</a></li>
-                <li><a href="">Mastodon</a></li>
-                <li><a href="">LinkedIn</a></li>
+                <li><a href="mailto:conference@foundation.matrix.org">Email</a></li>
+                <li><a href="https://mastodon.matrix.org/@matrix" rel="me">Mastodon</a></li>
+                <li><a href="https://www.linkedin.com/company/matrix-org/">LinkedIn</a></li>
             </ul>
         </section>
         <section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "skel.html" %}
 {% block head_extra %}
 <meta name="description"
-    content="The homepage of the matrix.org website. Chat securely with your family, friends, community, or build great apps with Matrix!">
+    content="The homepage of The Matrix Conference, the annual flagship event for people who care about free and open, secure, decentralised communications.">
 {% endblock head_extra %}
 {% block content %}
 <div id="index-content" class="page-content">
@@ -34,7 +34,7 @@
                     <p>Matrix is first and foremost built by its community. Learn what everyone is working on, share or
                         hack on projects, or hire experienced members.</p>
                     <p>The Matrix Conference is meant for everyone, and is accessible. Check out our <a
-                            href="/attend#health-and-safety">Accessibility and Health & Safety Pledge</a>.</p>
+                            href="/attend#health-and-safety">Accessibility and Health & Safety Policy</a>.</p>
                 </div>
                 <img src="/assets/frontpage/josh-speaker.png" width="545" height="400" alt="">
             </div>
@@ -46,7 +46,7 @@
             <div class="content">
                 <div class="visual-call">Become a sponsor</div>
                 <div class="info">
-                    <p>Partnering with the Matrix Conference provides a unique opportunity to connect with the Matrix
+                    <p>Partnering with The Matrix Conference provides a unique opportunity to connect with the Matrix
                         experts in the community. Don’t miss your chance to sponsor the flagship event of the Matrix
                         ecosystem.</p>
                     <a href="/sponsor" class="cta light-bg">Sponsor</a>
@@ -59,9 +59,9 @@
             <div class="content">
                 <div class="intro">
                     <h2>Scale your project up</h2>
-                    <p>Hundreds of attendees come to the Matrix Conference to learn what is happening in the ecosystem,
+                    <p>Hundreds of attendees come to The Matrix Conference to learn what is happening in the ecosystem,
                         show what they’re about, and find out where the ecosystem is going. Whether you’re a developer,
-                        SRE, project manager, student or something in-between, the Matrix Conference is your opportunity
+                        SRE, project manager, student or something in-between, The Matrix Conference is your opportunity
                         to…</p>
                 </div>
                 <div class="benefits">
@@ -97,22 +97,22 @@
                 <table>
                     <tr>
                         <td>Thursday 19, September</td>
-                        <td>Barcamp</td>
+                        <td>BarCamp</td>
                     </tr>
                     <tr>
                         <td>Friday 20, September</td>
-                        <td>Keynotes, BoFs, Breakout Sessions</td>
+                        <td>Keynotes, Open Spaces, Breakout Sessions</td>
                     </tr>
                     <tr>
                         <td>Saturday 21, September</td>
-                        <td>Keynotes, BoFs, Breakout Sessions</td>
+                        <td>Keynotes, Open Spaces, Breakout Sessions</td>
                     </tr>
                     <tr>
                         <td>Sunday 22, September</td>
-                        <td>Sprints</td>
+                        <td>Sprints and Community Meetings</td>
                     </tr>
                 </table>
-                <a href="https://cfp.matrix.org" class="cta">Propose a talk</a>
+                <a href="https://cfp.matrix.org" class="cta">Propose a Talk</a>
             </div>
         </div>
     </div>

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,5 +1,5 @@
 {% extends "skel.html" %}
-{% block html_title %}Matrix.org - {{ page.title }}{% endblock html_title %}
+{% block html_title %}The Matrix Conference - {{ page.title }}{% endblock html_title %}
 {% block head_extra %}
 {% if page.extra.meta_description %}
 <meta name="description" content="{{ page.extra.meta_description }}">

--- a/templates/register.html
+++ b/templates/register.html
@@ -6,12 +6,12 @@
             <div class="hero-text-wrapper">
                 <div class="hero-text">
                     <h1>Get your tickets now</h1>
-                    <p>Join us for first ever Matrix Conf in September 19 - 22. The four days conference will take place
-                        at Mitosis Labs. Talks will be streamed live and virtual attendees will be able to ask speakers
+                    <p>Join us for first ever Matrix Conference in September 19–22. The four day conference will take place
+                        at Mitosis LAB in Berlin. Talks will be streamed live and virtual attendees will be able to ask speakers
                         questions.</p>
                     <div class="cta-row">
                         <a href="#tickets" class="cta primary">Get Tickets</a>
-                        <a href="#venue" class="cta">Venue info</a>
+                        <a href="#venue" class="cta">Venue Info</a>
                     </div>
                 </div>
             </div>
@@ -22,7 +22,7 @@
             <div class="content blurb-and-image">
                 <div class="col">
                     <h2>We're looking forward to meeting you!</h2>
-                    <p>The official Matrix Conference is a great place for developers, architects, sysadmins, community
+                    <p>The Matrix Conference is a great place for developers, architects, sysadmins, community
                         leaders,
                         from the public and private sector, as well as students and anyone interested in open, secure,
                         decentralised communication.</p>
@@ -37,11 +37,11 @@
                 <img src="https://via.placeholder.com/550x260.png" alt="">
                 <div class="col">
                     <h2>Venue</h2>
-                    <p>The Matrix Conference will happen at Mitosis Labs, in Berlin. The venue is situated in an old
+                    <p>The Matrix Conference will happen at Mitosis LAB, in Berlin. The venue is situated in an old
                         factory, repurposed as “LABS” to organise events.</p>
                     <p>With several levels and an access to the garden, this venue is the perfect place to get together,
                         present new ideas and products, and bond together.</p>
-                    <a href="/attend#getting-there" class="cta">Getting there</a>
+                    <a href="/attend#getting-there" class="cta">Getting There</a>
                 </div>
             </div>
         </div>
@@ -51,10 +51,10 @@
             <div class="content blurb-and-image">
                 <div class="col">
                     <h2>Health & Safety</h2>
-                    <p>We’re going to have top notch ventilation, and the place will be wheelchair accessible.</p>
-                    <p>The Code of Conduct of the Matrix.org Foundation applies during the event. We expect attendees,
+                    <p>We’re going to have maximise ventilation, monitor air quality, require masks indoors, and the place will be wheelchair accessible.</p>
+                    <p>The Code of Conduct of The Matrix.org Foundation applies during the event. We expect attendees,
                         speakers, volunteers and staff to be excellent to each other.</p>
-                    <a href="/attend#health-and-safety" class="cta light-bg">Read our pledge</a>
+                    <a href="/attend#health-and-safety" class="cta light-bg">Read Our Policy</a>
                 </div>
             </div>
         </div>

--- a/templates/section.html
+++ b/templates/section.html
@@ -1,5 +1,5 @@
 {% extends "skel.html" %}
-{% block html_title %}Matrix.org - {{ section.title }}{% endblock html_title %}
+{% block html_title %}The Matrix Conference - {{ section.title }}{% endblock html_title %}
 {% block head_extra %}
 {% block scripts %}{% endblock scripts %}
 {% endblock head_extea %}

--- a/templates/skel.html
+++ b/templates/skel.html
@@ -27,7 +27,7 @@
     {% elif section.extra.meta_description %}
     {% set og_description = section.extra.meta_description %}
     {% else %}
-    {% set og_description = "Matrix, the open protocol for secure decentralised communications" %}
+    {% set og_description = "The Matrix Conference is coming to Berlin, Germany on September 19–22, 2024." %}
     {% endif %}
     <meta property="og:description" content="{{ og_description }}" />
     <meta name="description" content="{{ og_description }}" />
@@ -40,7 +40,7 @@
     {% endif %}
     <title>
         {%- if config.mode == "serve" -%}&#x1F6E0;&#xFE0F; {% endif -%}
-        {%- block html_title %}Matrix Conf{% endblock html_title -%}
+        {%- block html_title %}The Matrix Conference{% endblock html_title -%}
     </title>
     <link rel="shortcut icon" href="/assets/favicon.ico" />
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />

--- a/templates/sponsor.html
+++ b/templates/sponsor.html
@@ -6,13 +6,13 @@
             <div class="hero-text-wrapper">
                 <div class="hero-text">
                     <h1>Become a sponsor</h1>
-                    <p>Join us as a sponsor of the Matrix Conference 2024 and enjoy one of the many benefits that comes
+                    <p>Join us as a sponsor of The Matrix Conference 2024 and enjoy one of the many benefits that comes
                         with it.</p>
                     <p>Network with peers, raise brand awareness, recruit new team members, get to know about the latest
                         trends, developments in the Matrix Ecosystem.</p>
                     <div class="cta-row">
                         <a href="" class="cta primary">Prospectus</a>
-                        <a href="mailto:conference@foundation.matrix.org" class="cta">Contact us</a>
+                        <a href="mailto:conference@foundation.matrix.org" class="cta">Contact Us</a>
                     </div>
                 </div>
             </div>
@@ -24,7 +24,7 @@
             <div class="content">
                 <div class="intro">
                     <h2>Benefits of sponsorship</h2>
-                    <p>Sponsoring the Matrix Conference gives you the opportunity to reach a diverse and experienced
+                    <p>Sponsoring The Matrix Conference gives you the opportunity to reach a diverse and experienced
                         audience of Matrix enthusiasts.</p>
                     <p>With the explosive growth of Matrix in private and public sector, sponsoring the conference is an
                         opportunity to grow your brand recognition on an expanding market.</p>
@@ -32,23 +32,23 @@
                 <div class="benefits">
                     <div class="benefit-card">
                         <h3>Brand recognition</h3>
-                        <p>Make sure your brand name is known when talking about Matrix</p>
+                        <p>Make sure your brand name is known when talking about Matrix.</p>
                     </div>
                     <div class="benefit-card">
                         <h3>Recruit top talent</h3>
-                        <p>The most brilliant minds of the Matrix community will be around</p>
+                        <p>The most brilliant minds of the Matrix community will be around.</p>
                     </div>
                     <div class="benefit-card">
                         <h3>Generate leads</h3>
-                        <p>Get in touch with the major players and offer your services</p>
+                        <p>Get in touch with major players and offer your services.</p>
                     </div>
                     <div class="benefit-card">
                         <h3>Build together</h3>
-                        <p>Create new partnerships, build common projects, reduce costs</p>
+                        <p>Create new partnerships, build common projects, reduce costs.</p>
                     </div>
                     <div class="benefit-card">
                         <h3>Showcase your products</h3>
-                        <p>Display the products and services to prospective customers</p>
+                        <p>Demonstrate your work to prospective customers.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
an assortment of copy edits:

* page titles and default meta description
* consistent capitalization in buttons and headers
* consistent branding around The Matrix Conference and MatrixConf
* refinements to health & safety policy (and rename it from pledge to policy)
* social URLs in footer
* a few other minor copy edits

this includes #18 and supersedes #15 