### PR TITLE
fix pattern alignment on schedule page

### DIFF
--- a/sass/_programme.scss
+++ b/sass/_programme.scss
@@ -1,4 +1,8 @@
 #programme-content {
+    @media (min-width: 851px) {
+        --pattern-height: 6;
+    }
+
     #programme {
         overflow-x: scroll;
     }


### PR DESCRIPTION
before (lowest pattern repetition is cut off):
![image](https://github.com/user-attachments/assets/51fb6010-79d3-48a0-b2c7-cee5e59767bc)

after:
![image](https://github.com/user-attachments/assets/247e8346-019b-4310-969a-9fff815face1)
