### PR TITLE
Improve the flow of the spacing on the watch cards using a whole bunch of nested (not subgrid) grids

### DIFF
--- a/sass/_watch.scss
+++ b/sass/_watch.scss
@@ -149,64 +149,60 @@
         border-radius: 16px;
         overflow: clip;
         gap: 0;
-        // This dictates the height of the card
-        //aspect-ratio: 1/0.75;
 
-        .thumbnail-container {
-            width: 358px;
-            height: 200px;
-            background-color: #000;
-            overflow: clip;
-
-            img {
-                border-radius: 0;
-            }
-        }
-
-        a {
+        .infos {
             display: grid;
-            grid-template-rows: min-content 1fr;
-        }
-
-        .info-container {
-            padding: 24px;
-            display: grid;
-            grid-template-rows: min-content 1fr min-content min-content;
-            flex-direction: column;
+            grid-template-columns: 358px;
+            grid-template-rows: 200px min-content 1fr min-content min-content;
             gap: 12px;
             color: var(--color-text);
 
-            h2 {
-                font-size: 1.25rem;
-                line-height: 1.2;
-                margin-block: 0;
-                display: -webkit-inline-box;
-                -webkit-box-orient: vertical;
-                -webkit-line-clamp: 3;
+            .thumbnail-container {
+                background-color: #000;
+                border-radius: 0;
                 overflow: clip;
-                //height: 3lh;
-            }
 
-            p {
-                line-height: 1.4;
-                margin-block: 0;
-                font-size: 1rem;
-                display: -webkit-inline-box;
-                -webkit-box-orient: vertical;
-                -webkit-line-clamp: 3;
-                //text-overflow: ellipsis;
-                overflow: clip;
-                //height: 3lh;
+                img {
+                    border-radius: 0;
+                }
             }
+        }
 
-            .speaker {
-                font-size: .75rem;
-            }
+        h2 {
+            // There is already a gap of 12px between the image and the title
+            padding-top: 12px;
+            padding-inline: 24px;
+            font-size: 1.25rem;
+            line-height: 1.2;
+            margin-block: 0;
+            display: -webkit-inline-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 3;
+            overflow: clip;
+        }
 
-            .talk-pills {
-                display: flex;
-                gap: 8px;
-            }
+        .description {
+            padding-inline: 24px;
+            line-height: 1.4;
+            margin-block: 0;
+            font-size: 1rem;
+            display: -webkit-inline-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 3;
+            overflow: clip;
+            height: 3lh;
+        }
+
+        .speaker {
+            padding-inline: 24px;
+            font-size: .75rem;
+        }
+
+        .talk-pills {
+            padding-inline: 24px;
+            display: flex;
+            gap: 8px;
+            padding-bottom: 24px;
         }
 
         &:hover {

--- a/sass/_watch.scss
+++ b/sass/_watch.scss
@@ -137,15 +137,20 @@
     .talks-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, 358px);
+        grid-template-rows: repeat(auto-fit, 533px);
         row-gap: 48px;
         column-gap: 24px;
     }
 
     .talk-card {
-        display: block;
+        display: grid;
+        grid-template-rows: 1fr min-content;
         border: 1px solid #D2D2D2;
         border-radius: 16px;
         overflow: clip;
+        gap: 0;
+        // This dictates the height of the card
+        //aspect-ratio: 1/0.75;
 
         .thumbnail-container {
             width: 358px;
@@ -158,9 +163,15 @@
             }
         }
 
+        a {
+            display: grid;
+            grid-template-rows: min-content 1fr;
+        }
+
         .info-container {
             padding: 24px;
-            display: flex;
+            display: grid;
+            grid-template-rows: min-content 1fr min-content min-content;
             flex-direction: column;
             gap: 12px;
             color: var(--color-text);
@@ -172,8 +183,8 @@
                 display: -webkit-inline-box;
                 -webkit-box-orient: vertical;
                 -webkit-line-clamp: 3;
-                /*overflow: clip;*/
-                height: 3lh;
+                overflow: clip;
+                //height: 3lh;
             }
 
             p {
@@ -183,8 +194,9 @@
                 display: -webkit-inline-box;
                 -webkit-box-orient: vertical;
                 -webkit-line-clamp: 3;
+                //text-overflow: ellipsis;
                 overflow: clip;
-                height: 3lh;
+                //height: 3lh;
             }
 
             .speaker {

--- a/templates/macros/talk-card.html
+++ b/templates/macros/talk-card.html
@@ -1,13 +1,14 @@
 {% macro talk_card(talk) %}
 <div class="talk-card {{ talk.track | slugify }}">
     {% if talk.youtube %}
-    <a href="{% if talk.youtube %}{{ talk.youtube }}{% else %}#{% endif %}">
+    <a class="infos" href="{% if talk.youtube %}{{ talk.youtube }}{% else %}#{% endif %}">
         <div class="thumbnail-container">
             <img src="/watch/{{ talk.title | slugify }}.webp" alt="">
         </div>
-        <div class="info-container">
-            <h2>{{ talk.title }}</h2>
-            <p>{{ talk.summary }}</p>
+        <h2>{{ talk.title }}</h2>
+        <p class="description">
+            {{ talk.summary }}
+            </dpiv>
             <div class="speaker">
                 {{ talk.speakers | join(sep=", ") }}
             </div>
@@ -15,24 +16,23 @@
                 <div class="pill {{ talk.track | slugify }}">{{ talk.track | title }}</div>
                 <div class="pill room">{{ talk.room }}</div>
             </div>
-        </div>
     </a>
     {% else %}
-    <div>
+    <div class="infos">
         <div class="thumbnail-container">
             <img src="/watch/{{ talk.title | slugify }}.webp" alt="">
         </div>
-        <div class="info-container">
-            <h2>{{ talk.title }}</h2>
-            <p>{{ talk.summary }}</p>
-            <div class="speaker">
-                {{ talk.speakers | join(sep=", ") }}
-            </div>
-            <div class="talk-pills">
-                <div class="pill {{ talk.track | slugify }}">{{ talk.track | title }}</div>
-                <div class="pill room">{{ talk.room }}</div>
-                <div class="pill no-video">No Recording</div>
-            </div>
+        <h2>{{ talk.title }}</h2>
+        <p class="description">
+            {{ talk.summary }}
+        </p>
+        <div class="speaker">
+            {{ talk.speakers | join(sep=", ") }}
+        </div>
+        <div class="talk-pills">
+            <div class="pill {{ talk.track | slugify }}">{{ talk.track | title }}</div>
+            <div class="pill room">{{ talk.room }}</div>
+            <div class="pill no-video">No Recording</div>
         </div>
     </div>
     {% endif %}


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/e323f9b0-9e0e-42d2-b5a3-41808a214ee2)

This is not perfect either but it seems to have better text flow than whats on main now that I had to untruncate the headers since those hid valuable information.

kinda helps #70 ?

cc review from @HarHarLinks appreciated (cant do it via github itself :|)