### PR TITLE
Add empty sections placeholder if filters are applied

### DIFF
--- a/src/pages/watch.astro
+++ b/src/pages/watch.astro
@@ -105,7 +105,7 @@ for (let i = 0; i < 3; i++) {
         align-items: center;
         gap: 12px;
         margin-top: 48px;
-        margin-bottom: 48px;
+        margin-bottom: 24px;
 
         .date {
             flex: none;
@@ -137,7 +137,7 @@ for (let i = 0; i < 3; i++) {
     }
 
     .empty-section {
-        color: var(--border);
+        color: var(--text-secondary);
         font-size: 1.25rem;
         text-align: center;
     }
@@ -145,6 +145,7 @@ for (let i = 0; i < 3; i++) {
     @media (min-width: 768px) {
         .empty-section {
             font-size: 2rem;
+            margin-bottom: 48px;
         }
     }
 </style>


### PR DESCRIPTION
### Description

At the moment if filters are applied on https://2025.matrix.org/watch/ there may be empty sections.

This PR extends the filters to show a section placeholder if a day is empty.

### Related issues

closes https://github.com/matrix-org/matrix-conf-website/issues/163

### Role

individual

### Timeline

yesterday

### Signoff

Please [sign off](https://github.com/matrix-org/matrix-conf-website/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to The Matrix Conference website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix-conf-website/blob/main/README.md
     - https://github.com/matrix-org/matrix-conf-website/blob/main/CONTRIBUTING.md

     The processes for this website are inherited from the matrix.org main website repository at
     https://github.com/matrix-org/matrix.org/.
     
     If you have questions at any time, please contact the Events Working Group (about content) at
     https://matrix.to/#/#events-wg:matrix.org
     or the Website & Content Working Group (about tech) at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
