### PR TITLE
Remove loading=lazy from talk thumbnails

### DIFF
--- a/src/components/WatchCard.astro
+++ b/src/components/WatchCard.astro
@@ -1,10 +1,6 @@
 ---
 interface Props {
     talk: CollectionEntry<"talks">;
-    /**
-     * True to set loading="lazy" on the talk thumbnail
-     */
-    lazyThumb?: boolean;
 }
 
 import slugify from '@sindresorhus/slugify';
@@ -14,7 +10,7 @@ import WatchCardContent from "../components/WatchCardContent.astro";
 import { Image } from "astro:assets";
 import LogoNoPattern from "./logo-no-pattern.svg";
 
-const { lazyThumb, talk } = Astro.props;
+const { talk } = Astro.props;
 const youtube = talk.data.youtube;
 const title = talk.data['Proposal title'];
 const talkId = talk.data.ID;
@@ -120,7 +116,6 @@ const room = talk.data.Room.en;
             alt={speakerNames}
             height="900"
             width="1600"
-            loading={lazyThumb ? 'lazy' : 'eager'}
         />
         <div class="info-container">
             <h2>{ title }</h2>

--- a/src/pages/watch.astro
+++ b/src/pages/watch.astro
@@ -175,8 +175,8 @@ for (let i = 0; i < 3; i++) {
                 <div class="line"></div>
             </div>
             <div class="talks-grid">
-                {days_talks.map((talk: any, index) => (
-                    <WatchCard talk={talk} lazyThumb={index > 5} />
+                {days_talks.map((talk: any) => (
+                    <WatchCard talk={talk} />
                 ))}
             </div>
             ))}


### PR DESCRIPTION
### Description

Thumbnails have been sized down, so this is no longer important. Also prevents images to load when scrolling down or applying filters.

### Related issues

resolves https://github.com/matrix-org/matrix-conf-website/issues/166

### Role

individual

### Timeline

do it!

### Signoff

Please [sign off](https://github.com/matrix-org/matrix-conf-website/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to The Matrix Conference website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix-conf-website/blob/main/README.md
     - https://github.com/matrix-org/matrix-conf-website/blob/main/CONTRIBUTING.md

     The processes for this website are inherited from the matrix.org main website repository at
     https://github.com/matrix-org/matrix.org/.
     
     If you have questions at any time, please contact the Events Working Group (about content) at
     https://matrix.to/#/#events-wg:matrix.org
     or the Website & Content Working Group (about tech) at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
