### PR TITLE
Fix paddings on 2025 home

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -44,11 +44,11 @@ import Rooms from "../components/Rooms.astro";
     </section>
     <section id="schedule">
         <RoughSchedule />
-        <section id="new-heights">
-            <NewHeights />
-        </section>
-        <section id="talks-2024">
-            <Talks2024 />
-        </section>
+    </section>
+    <section id="new-heights">
+        <NewHeights />
+    </section>
+    <section id="talks-2024">
+        <Talks2024 />
     </section>
 </BaseLayout>


### PR DESCRIPTION
### Description

There were a few sections in sections.

Spacing between sections became larger with this change. But now it is the same between every section.

| Before | After |
| --- | --- |
|  <img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/46bb4932-500a-463f-b6e1-a5e41f8429ff" /> | <img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/b0ec1466-0420-46cb-b35f-fb638071966c" /> |

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

### Role

Website WG



### Signoff

Please [sign off](https://github.com/matrix-org/matrix-conf-website/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to The Matrix Conference website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix-conf-website/blob/main/README.md
     - https://github.com/matrix-org/matrix-conf-website/blob/main/CONTRIBUTING.md

     The processes for this website are inherited from the matrix.org main website repository at
     https://github.com/matrix-org/matrix.org/.
     
     If you have questions at any time, please contact the Events Working Group (about content) at
     https://matrix.to/#/#events-wg:matrix.org
     or the Website & Content Working Group (about tech) at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
