### PR TITLE
Add ticket CTAs on main and attend page

### DIFF
--- a/src/components/Teaser2026.astro
+++ b/src/components/Teaser2026.astro
@@ -24,6 +24,20 @@ import CfP from "./CfP.astro";
         padding: 1rem;
     }
 
+    .actions {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    @media (min-width: 800px) {
+        .actions {
+            flex-direction: row;
+            margin-top: auto;
+            width: fit-content;
+        }
+    }
+
     .smol {
         @media (min-width: 800px) {
             flex-basis: 40%;
@@ -64,12 +78,20 @@ import CfP from "./CfP.astro";
                 Learn all about the venue, how to get there, where to stay,
                 and any partner offers available with your #MatrixConf ticket.
             </p>
-            <PrimaryCta
-                href="/attend"
-                flexBottom={true}
-            >
-            Practical Info
-            </PrimaryCta>
+            <div class="actions">
+                <PrimaryCta
+                    href="/attend"
+                    flexBottom={true}
+                >
+                    Practical Info
+                </PrimaryCta>
+                <PrimaryCta
+                    href="/register"
+                    flexBottom={true}
+                >
+                    Tickets
+                </PrimaryCta>
+            </div>
         </div>
         <div class="item smol">
             <h2>Become a Sponsor</h2>

--- a/src/pages/attend.astro
+++ b/src/pages/attend.astro
@@ -47,8 +47,8 @@ const pageDescription = "Join us for The Matrix Conference from 20th to 23rd Oct
     }
 </style>
 <BaseLayout
-    pageTitle="{ pageTitle }"
-    description="{ pageDescription }"
+    pageTitle={ pageTitle }
+    description={ pageDescription }
 >
     <section id="overview">
         <div class="content-wrapper">

--- a/src/pages/attend.astro
+++ b/src/pages/attend.astro
@@ -1,10 +1,14 @@
 ---
 import GettingThere from "../components/GettingThere.astro";
 import HealthSafetyPolicy from "../components/HealthSafetyPolicy.astro";
+import PrimaryCta from "../components/PrimaryCta.astro";
 import TextAndImage from "../components/TextAndImage.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import Venue from "../img/Scandic.avif";
 import Buffet from "../img/Buffet.png";
+
+const pageTitle = "Useful Facts";
+const pageDescription = "Join us for The Matrix Conference from 20th to 23rd October, 2026. The four day conference will take place in Malmö, Sweden. Talks will be streamed live and virtual attendees will be able to ask speakers questions.";
 ---
 
 <style>
@@ -32,6 +36,10 @@ import Buffet from "../img/Buffet.png";
         flex-grow: 1;
     }
 
+    .actions {
+        margin-top: 1rem;
+    }
+
     .smol {
         @media (min-width: 800px) {
             flex-basis: 40%;
@@ -39,9 +47,26 @@ import Buffet from "../img/Buffet.png";
     }
 </style>
 <BaseLayout
-    pageTitle="Useful Facts"
-    description="Join us for The Matrix Conference from 20th to 23rd October, 2026. The four day conference will take place in Malmö, Sweden. Talks will be streamed live and virtual attendees will be able to ask speakers questions."
+    pageTitle="{ pageTitle }"
+    description="{ pageDescription }"
 >
+    <section id="overview">
+        <div class="content-wrapper">
+            <h2>{ pageTitle }</h2>
+            <p>
+                { pageDescription }
+            </p>
+            <div class="actions">
+                <PrimaryCta
+                    href="/register"
+                    flexBottom={true}
+                >
+                    Get Your Tickets
+                </PrimaryCta>
+            </div>
+        </div>
+    </section>
+
     <section id="venue">
         <TextAndImage imgSrc={Venue}>
             <h2>The Venue</h2>


### PR DESCRIPTION
### Description

Adds ticket CTAs on the main page „Attend“ box and the attend page.

I added a title at the top of the attend page where I could place the button. It just repeats the title and description.

| Page | Screenshot |
| --- | --- |
| Attend (wide) | <img width="1920" height="1052" alt="image" src="https://github.com/user-attachments/assets/2478c47e-6d3e-4d41-a7fc-5c02ed26326c" /> |
| Attend (narrow) | <img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/88f9f38d-f239-4609-bfce-a7678d104478" /> |
| Home (wide) | sorry, GitHub wouldn't let me upload another screenshot 🤷  |
| Home (narrow) | <img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/727372d7-cfea-4350-a9f0-1daef4b6b5b4" /> |

### Related issues

closes #204

### Role

Website WG



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to The Matrix Conference website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix-conf-website/blob/main/README.md
     - https://github.com/matrix-org/matrix-conf-website/blob/main/CONTRIBUTING.md

     The processes for this website are inherited from the matrix.org main website repository at
     https://github.com/matrix-org/matrix.org/.
     
     If you have questions at any time, please contact the Events Working Group (about content) at
     https://matrix.to/#/#events-wg:matrix.org
     or the Website & Content Working Group (about tech) at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
