### PR TITLE
Ensure Pretix shop links are visible when focused

### DIFF
--- a/src/components/Tickets.astro
+++ b/src/components/Tickets.astro
@@ -25,9 +25,9 @@
         text-decoration: none;
     }
 
-    :global(.pretix-widget a:hover) {
+    :global(.pretix-widget a:hover),
+    :global(.pretix-widget a:focus) {
         color: var(--link-color);
-        text-decoration: underline;
     }
 
     :global(.pretix-widget-item-title-and-description) {


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Add styling to ensure focused links are visible. `text-decoration` was removed since it is defined in `https://pretix.eu/matrix/matrix-conf-2026/widget/v2.css`.

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

Closes #207.

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Member of The Matrix.org Foundation Website & Content Working Group.

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

There’s no immediate deadline.

### Signoff

Please [sign off](https://github.com/matrix-org/matrix-conf-website/blob/main/CONTRIBUTING.md) your individual commits.

<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to The Matrix Conference website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix-conf-website/blob/main/README.md
     - https://github.com/matrix-org/matrix-conf-website/blob/main/CONTRIBUTING.md

     The processes for this website are inherited from the matrix.org main website repository at
     https://github.com/matrix-org/matrix.org/.
     
     If you have questions at any time, please contact the Events Working Group (about content) at
     https://matrix.to/#/#events-wg:matrix.org
     or the Website & Content Working Group (about tech) at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
