### PR TITLE
Consolidate multiple `:global` selectors for Pretix links into a single selector in `Tickets.astro`

### DIFF
--- a/src/components/Tickets.astro
+++ b/src/components/Tickets.astro
@@ -26,8 +26,8 @@
     }
 
     :global(
-        .pretix-widget a:hover,
-        .pretix-widget a:focus
+            .pretix-widget a:hover,
+            .pretix-widget a:focus
         ) {
         color: var(--link-color);
     }

--- a/src/components/Tickets.astro
+++ b/src/components/Tickets.astro
@@ -25,8 +25,10 @@
         text-decoration: none;
     }
 
-    :global(.pretix-widget a:hover),
-    :global(.pretix-widget a:focus) {
+    :global(
+        .pretix-widget a:hover,
+        .pretix-widget a:focus
+        ) {
         color: var(--link-color);
     }
 


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Refactor the styling introduced in #208 to use just a singular `:global` selector. Nothing major, just a _slight_ tidy-up.

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

There are no issues related to this change, as it is a rather small modification. However, please see [this](https://github.com/matrix-org/matrix-conf-website/pull/208#issuecomment-4416846108) comment.

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Member of The Matrix.org Foundation Website & Content Working Group.

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

There’s no immediate deadline.


### Signoff

Please [sign off](https://github.com/matrix-org/matrix-conf-website/blob/main/CONTRIBUTING.md) your individual commits.

<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to The Matrix Conference website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix-conf-website/blob/main/README.md
     - https://github.com/matrix-org/matrix-conf-website/blob/main/CONTRIBUTING.md

     The processes for this website are inherited from the matrix.org main website repository at
     https://github.com/matrix-org/matrix.org/.
     
     If you have questions at any time, please contact the Events Working Group (about content) at
     https://matrix.to/#/#events-wg:matrix.org
     or the Website & Content Working Group (about tech) at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
